### PR TITLE
#19 - 회원 계정 엔티티와 게시글, 댓글에 연관 관계적용

### DIFF
--- a/src/main/java/com/seungmin/projectboard/domain/Article.java
+++ b/src/main/java/com/seungmin/projectboard/domain/Article.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 import java.util.Set;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 @Table(indexes = {
         @Index(columnList = "title"),
         @Index(columnList = "hashtag"),
@@ -31,25 +31,27 @@ public class Article extends AuditingFields{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
+    @Setter @ManyToOne(optional = false) private  UserAccount userAccount;
     @Setter @Column(nullable = false) private String title;  // 제목
     @Setter @Column(nullable = false, length = 10000) private String content;  // 본문
 
     @Setter private String hashtag;  // 해시태그
 
-    @OrderBy("id")
+    @OrderBy("createdAt DESC")
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     @ToString.Exclude
     private final Set<ArticleComment> articleComments = new LinkedHashSet<>();
 
 
     protected Article() {}
-    private Article(String title, String content, String hashtag) {
+    private Article(UserAccount userAccount, String title, String content, String hashtag) {
+        this.userAccount = userAccount;
         this.title = title;
         this.content = content;
         this.hashtag = hashtag;
     }
-    public static Article of(String title, String content, String hashtag) {
-        return new Article(title, content, hashtag);
+    public static Article of(UserAccount userAccount, String title, String content, String hashtag) {
+        return new Article(userAccount, title, content, hashtag);
     }
 
     @Override

--- a/src/main/java/com/seungmin/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/seungmin/projectboard/domain/ArticleComment.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 @Table(indexes = {
         @Index(columnList = "content"),
         @Index(columnList = "createdAt"),
@@ -29,17 +29,18 @@ public class ArticleComment extends AuditingFields {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
     @Setter @ManyToOne(optional = false) private Article article;  // 게시글 (ID)
+    @Setter @ManyToOne(optional = false) private UserAccount userAccount; //유저정보(ID)
     @Setter @Column(nullable = false, length = 500) private String content;  // 본문
 
 
     protected ArticleComment() {}
 
-    private ArticleComment(Article article, String content) {
+    private ArticleComment(Article article, UserAccount userAccount, String content) {
         this.article = article;
         this.content = content;
     }
-    public static ArticleComment of(Article article, String content) {
-        return new ArticleComment(article, content);
+    public static ArticleComment of(Article article, UserAccount userAccount, String content) {
+        return new ArticleComment(article, userAccount, content);
     }
 
     @Override

--- a/src/main/java/com/seungmin/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/seungmin/projectboard/domain/UserAccount.java
@@ -1,0 +1,58 @@
+package com.seungmin.projectboard.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Getter
+@ToString
+@Table(indexes = {
+        @Index(columnList = "userId"),
+        @Index(columnList = "email", unique = true),
+        @Index(columnList = "createdAt"),
+        @Index(columnList = "createdBy")
+})
+@Entity
+public class UserAccount extends AuditingFields {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter @Column(nullable = false, length = 50) private String userId;
+    @Setter @Column(nullable = false) private String userPassword;
+
+    @Setter @Column(length = 100) private String email;
+    @Setter @Column(length = 100) private String nickname;
+    @Setter private String memo;
+
+
+    protected UserAccount() {}
+
+    private UserAccount(String userId, String userPassword, String email, String nickname, String memo) {
+        this.userId = userId;
+        this.userPassword = userPassword;
+        this.email = email;
+        this.nickname = nickname;
+        this.memo = memo;
+    }
+
+    public static UserAccount of(String userId, String userPassword, String email, String nickname, String memo) {
+        return new UserAccount(userId, userPassword, email, nickname, memo);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserAccount userAccount)) return false;
+        return id != null && id.equals(userAccount.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+}

--- a/src/main/java/com/seungmin/projectboard/repository/UserAccountRepository.java
+++ b/src/main/java/com/seungmin/projectboard/repository/UserAccountRepository.java
@@ -1,0 +1,7 @@
+package com.seungmin.projectboard.repository;
+
+import com.seungmin.projectboard.domain.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+}

--- a/src/test/java/com/seungmin/projectboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/seungmin/projectboard/repository/JpaRepositoryTest.java
@@ -2,6 +2,7 @@ package com.seungmin.projectboard.repository;
 
 import com.seungmin.projectboard.config.JpaConfig;
 import com.seungmin.projectboard.domain.Article;
+import com.seungmin.projectboard.domain.UserAccount;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,12 +24,15 @@ class JpaRepositoryTest {
 
     private final ArticleRepository articleRepository;
     private final ArticleCommentRepository articleCommentRepository;
+    private final UserAccountRepository userAccountRepository;
 
     public JpaRepositoryTest(
            @Autowired ArticleRepository articleRepository,
-           @Autowired ArticleCommentRepository articleCommentRepository) {
+           @Autowired ArticleCommentRepository articleCommentRepository,
+           @Autowired UserAccountRepository userAccountRepository) {
         this.articleRepository = articleRepository;
         this.articleCommentRepository = articleCommentRepository;
+        this.userAccountRepository = userAccountRepository;
     }
 
     @DisplayName("select 테스트")
@@ -48,7 +52,9 @@ class JpaRepositoryTest {
 
         long previousCount = articleRepository.count();
 
-        Article savedArticle = articleRepository.save(Article.of("new article", "new content", "#spring"));
+        UserAccount userAccount = userAccountRepository.save(UserAccount.of("uno", "pw", null, null, null));
+        Article article = Article.of(userAccount, "new article", "new content", "#spring");
+        articleRepository.save(article);
 
         assertThat(articleRepository.count()).isEqualTo(previousCount +1);
 


### PR DESCRIPTION
도메인 수정 - 회원 계정과 게시글, 댓글 관계 연결

This closes #19 